### PR TITLE
Fix Vercel build by configuring output directory

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,6 @@
+{
+  "buildCommand": "cd apps/website && npm run build",
+  "outputDirectory": "apps/website/.vercel/output",
+  "installCommand": "npm install",
+  "framework": null
+}


### PR DESCRIPTION
Added vercel.json to specify:
- Build command to run website app build
- Output directory for SvelteKit adapter-vercel
- Install command for monorepo dependencies

This fixes the issue where Turbo found no tasks to execute and Vercel couldn't find the output directory.